### PR TITLE
fix: Add architecture configuration for nomone

### DIFF
--- a/arch-config.json
+++ b/arch-config.json
@@ -5,6 +5,11 @@
     "arches": ["arm64-v8a", "armeabi-v7a"]
   },
   {
+    "app_name": "nomone",
+    "source": "morphe",
+    "arches": ["arm64-v8a", "armeabi-v7a"]
+  },
+  {
     "app_name": "google-photos",
     "source": "rookie",
     "arches": ["arm64-v8a", "armeabi-v7a"]


### PR DESCRIPTION
## Summary

The nomone app was failing to install with an `INSTALL_FAILED_NO_MATCHING_ABIS` error. This was because it was missing from the architecture configuration, causing the build to lack the necessary native libraries for modern devices. This change adds `nomone` to `arch-config.json` to ensure it's built with `arm64-v8a` and `armeabi-v7a` support, resolving the installation issue.

## Changes

- **arch-config.json**: Added an entry for the 'nomone' app to `arch-config.json`. This ensures that the build process includes the necessary native libraries (ABIs) for `arm64-v8a` and `armeabi-v7a`, fixing the `INSTALL_FAILED_NO_MATCHING_ABIS` error during installation.

## Related Issue

Closes #38

